### PR TITLE
feat: add reload method and deprecate git_root in favour of lspconfig one

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ to enable the external config feature.
 require('dap-go').setup({
   external_config = {
     enable = true,
-    path = require('dap-go.util').git_root(vim.loop.fs_realpath('.')) .. '/dap-go.json'
+    path = require('lspconfig.util').find_git_ancestor(vim.loop.fs_realpath('.')) .. '/dap-go.json'
   }
 })
 ```

--- a/doc/dap-go.txt
+++ b/doc/dap-go.txt
@@ -27,7 +27,7 @@ dapgo.setup({options})                                         *dapgo.setup()*
       --- Enable external config
       enabled = false,
       --- File with the config definitions.
-      path = require('dap-go.util').git_root(uv.fs_realpath('.')) .. '/dap-go.json',
+      path = require('lspconfig.util').find_git_ancestor(vim.loop.fs_realpath('.')) .. '/dap-go.json',
     },
 
     --- nvim-dap configuration for go.
@@ -86,7 +86,7 @@ config.setup({options})                                       *config.setup()*
        --- Enable external config
        enabled = false,
        --- File with the config definitions.
-       path = require('dap-go.util').git_root(uv.fs_realpath('.')) .. '/dap-go.json',
+       path = require('lspconfig.util').find_git_ancestor(vim.loop.fs_realpath('.')) .. '/dap-go.json',
      },
 
      --- nvim-dap configuration for go.
@@ -150,17 +150,6 @@ This class provides common functions used in dap-go extension.
 
 Util                                                                    *Util*
     Collection of utility fuctions.
-
-
-util.git_root({name})                                        *util.git_root()*
-    Gets the git root of the project base on a file from it.
-
-
-    Parameters: ~
-        {name} (string)  Name of the current file to start the search from.
-
-    Return: ~
-        string: Path of the git root.
 
 
 util.json_encode({data})                                  *util.json_encode()*

--- a/doc/dap-go.txt
+++ b/doc/dap-go.txt
@@ -56,6 +56,14 @@ dapgo.setup({options})                                         *dapgo.setup()*
         {options} (table)  @Configuration opts. Keys: external_config, dap
 
 
+dapgo.reload({options})                                       *dapgo.reload()*
+    Reload dap-go module
+
+
+    Parameters: ~
+        {options} (table)  @Configuration opts. Keys: external_config, dap
+
+
 
 ================================================================================
                                                                  *dap-go.config*

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -123,4 +123,11 @@ function dapgo.setup(options)
   setup_adapter()
 end
 
+---Reload dap-go module
+---@param options table: @Configuration opts. Keys: external_config, dap
+function dapgo.reload(options)
+  require('plenary.reload').reload_module('dap-go')
+  require('dap-go').setup(options)
+end
+
 return dapgo

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -91,7 +91,7 @@ end
 ---   --- Enable external config
 ---   enabled = false,
 ---   --- File with the config definitions.
----   path = require('dap-go.util').git_root(uv.fs_realpath('.')) .. '/dap-go.json',
+---   path = require('lspconfig.util').find_git_ancestor(vim.loop.fs_realpath('.')) .. '/dap-go.json',
 --- },
 ---
 --- --- nvim-dap configuration for go.

--- a/lua/dap-go/config.lua
+++ b/lua/dap-go/config.lua
@@ -24,7 +24,7 @@ local defaults = {
     --- Enable external config
     enabled = false,
     --- File with the config definitions.
-    path = require('dap-go.util').git_root(uv.fs_realpath('.')) .. '/dap-go.json',
+    path = require('lspconfig.util').find_git_ancestor(uv.fs_realpath('.')) .. '/dap-go.json',
   },
 
   --- nvim-dap configuration for go.
@@ -80,7 +80,7 @@ end
 ---    --- Enable external config
 ---    enabled = false,
 ---    --- File with the config definitions.
----    path = require('dap-go.util').git_root(uv.fs_realpath('.')) .. '/dap-go.json',
+---    path = require('lspconfig.util').find_git_ancestor(vim.loop.fs_realpath('.')) .. '/dap-go.json',
 ---  },
 ---
 ---  --- nvim-dap configuration for go.

--- a/lua/dap-go/util.lua
+++ b/lua/dap-go/util.lua
@@ -15,13 +15,6 @@ function util.load_module(name)
   return module
 end
 
---- Gets the git root of the project base on a file from it.
----@param name string: Name of the current file to start the search from.
----@return string: Path of the git root.
-function util.git_root(name)
-  return require('lspconfig.util').root_pattern('.git')(name)
-end
-
 --- Encodes string data to JSON.
 ---@usage
 ---@note borrowed from https://github.com/tjdevries/tree-sitter-lua/blob/master/lua/nlsp/rpc.lua


### PR DESCRIPTION
# Description

This PR adds the `reload` method to easily reload file configurations.

# Changelog
- Add `reload` method
- Replace `dap-go.config.git_root` by function from native lsconfig Neovim's plugin
