### PR TITLE
Fix on recent neovim build

### DIFF
--- a/doc/dap-go.txt
+++ b/doc/dap-go.txt
@@ -23,6 +23,7 @@ dapgo.setup({options})                                         *dapgo.setup()*
     Usage:
     >
     require('dap-go').setup({
+    delay = 100 -- in ms, how much time to wait before connecting to dlv
     external_config = {
       --- Enable external config
       enabled = false,
@@ -85,6 +86,7 @@ config.setup({options})                                       *config.setup()*
     Usage:
     >
     require('dap-go').setup{
+    delay = 100 -- in ms, how much time to wait before connecting to dlv
      external_config = {
        --- Enable external config
        enabled = false,

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -53,7 +53,7 @@ local function on_stderr()
   return function() end
 end
 
-local function setup_adapter()
+local function setup_adapter(delay)
   dap.adapters.go = function(cb, configuration)
     local host = configuration.host or '127.0.0.1'
     local port = configuration.port or '38697'
@@ -76,10 +76,8 @@ local function setup_adapter()
       :start()
 
     vim.defer_fn(function()
-      -- I have no idea why this is required, I suspect the firewall or something else?
-      os.execute("sleep " .. tonumber(1))
       cb({ type = 'server', host = host, port = port })
-    end, 100)
+    end, delay)
   end
 end
 
@@ -89,6 +87,7 @@ end
 --- Usage:
 --- <code>
 --- require('dap-go').setup({
+--- delay = 100, -- ms
 --- external_config = {
 ---   --- Enable external config
 ---   enabled = false,
@@ -125,7 +124,7 @@ function dapgo.setup(options)
 
   ---@diagnostic disable-next-line: undefined-field
   dap.configurations.go = config.dap.configurations
-  setup_adapter()
+  setup_adapter(options.delay)
 end
 
 ---Reload dap-go module

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -76,6 +76,8 @@ local function setup_adapter()
       :start()
 
     vim.defer_fn(function()
+      -- I have no idea why this is required, I suspect the firewall or something else?
+      os.execute("sleep " .. tonumber(1))
       cb({ type = 'server', host = host, port = port })
     end, 100)
   end

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -59,7 +59,7 @@ local function setup_adapter()
     local port = configuration.port or '38697'
     local addr = string.format('%s:%s', host, port)
 
-    if configuration.options.env then
+    if configuration.options and configuration.options.env then
       env.extend(configuration.options.env)
     end
 

--- a/lua/dap-go/config.lua
+++ b/lua/dap-go/config.lua
@@ -20,6 +20,7 @@ function mt:__index(k)
 end
 
 local defaults = {
+  delay = 100, -- ms
   external_config = {
     --- Enable external config
     enabled = false,
@@ -80,6 +81,7 @@ end
 --- Usage:
 --- <code>
 --- require('dap-go').setup{
+--- delay = 100, -- ms
 ---  external_config = {
 ---    --- Enable external config
 ---    enabled = false,


### PR DESCRIPTION
I was configuring my go env and struggled to get `dap-go.nvim` to work. I managed to fix the two issues that were blocking me and included them in this PR. 

I'm not sure of what is happening, but I thought that bringing them forward would be useful in case someone else is blocked or if you want to investigate. 

```
:version                                                                                                                                                                                                                                                                                                                                                                                                   
NVIM v0.7.0-dev+923-gecec95712                                                                                                                                                                                                                                                                                                                                                                             
Build type: Release                                                                                                                                                                                                                                                                                                                                                                                        
LuaJIT 2.1.0-beta3               
```